### PR TITLE
Fix build error in MacOS 12 and Xcode 12.4 .

### DIFF
--- a/libzmq.rb
+++ b/libzmq.rb
@@ -255,6 +255,8 @@ for platform in PLATFORMS
       "--enable-static",
       "--host=#{host}",
       "--with-libsodium=#{LIBSODIUM_DIST}/#{platform}",
+      "--disable-perf",
+      "--disable-curve-keygen",
     ]
     exit 1 unless system(configure_cmd.join(" "))
 


### PR DESCRIPTION
Fix build error in MacOS 12 and Xcode 12.4 . Referenced this: https://github.com/mceSystems/libzmq/blob/master/builds/ios/build_ios.sh

Signed-off-by: kukgini <kukgini@gmail.com>